### PR TITLE
added colorChoice reset in order to prevent museum page from loading …

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -69,6 +69,7 @@ function App() {
         setProductColors([]) //Reset colours so the previous colours don't get used
         setBrandName(brand);
         setSubmit(true);
+        setColorChoice('');// removes colour choice so that if a previous painting was shown it no longer will be
         setUserSelect('userSelectMade')
         setScreen('AppScreen2')
     }

--- a/src/Components/BrandColor.js
+++ b/src/Components/BrandColor.js
@@ -9,9 +9,7 @@ const BrandColor = (props) => {
 
                     return(
                         <li key={index}>
-                            {/* <div className="colorBox" style={{backgroundColor: `${color}`}}> */}
                                 <button className="colorBox" style={{backgroundColor: `${color}`}} onClick={props.handleColorChoice} value={color}>{color}</button>
-                            {/* </div> */}
                         </li>
                     )
                 })


### PR DESCRIPTION
…on new brand select

When user submits their brand choice, the colourChoice state is reset so that museum page does not display in order to show a new image for the new brand.